### PR TITLE
athena error message fix

### DIFF
--- a/sroka/api/athena/athena_api.py
+++ b/sroka/api/athena/athena_api.py
@@ -2,75 +2,10 @@ from configparser import NoOptionError
 from urllib.parse import urlparse
 
 import boto3
-import pandas as pd
 from botocore.exceptions import ClientError, EndpointConnectionError
-from retrying import retry
 
 import sroka.config.config as config
-
-
-@retry(stop_max_attempt_number=10,
-       wait_exponential_multiplier=1 * 1000,
-       wait_exponential_max=10 * 60 * 1000)
-def poll_status(session, _id):
-    try:
-        result = session.get_query_execution(
-            QueryExecutionId=_id
-        )
-    except ClientError as e:
-        if e.response['Error']['Code'] == 'InvalidRequestException':
-            print("Please check your query_id. Error message:")
-        else:
-            print("ClientError. Error message:")
-        print(e)
-        return None
-    except EndpointConnectionError as e:
-        print('Please check your credentials including aws_region in config.ini file and Internet connection.',
-              'Error message:')
-        print(e)
-        return None
-
-    state = result['QueryExecution']['Status']['State']
-
-    if state in ('SUCCEEDED', 'FAILED', 'CANCELLED'):
-        return result
-    else:
-        print('Waiting for {} query to end'.format(_id))
-        raise Exception
-
-
-def download_file(s3, s3_bucket, s3_key, filename):
-    if filename:
-        try:
-            s3.Bucket(s3_bucket).download_file(s3_key, filename)
-        except FileNotFoundError as e:
-            print('File or folder not found. Error message:')
-            print(e)
-            return None
-        except ClientError as e:
-            if e.response['Error']['Code'] == 'InvalidRequestException':
-                print("Please check your query. Error message:")
-            elif e.response['Error']['Code'] == '':
-                print('')
-            else:
-                print('Please check your credentials including s3_bucket in config.ini file. Error message:')
-            print(e)
-            return None
-        print('saved to ' + filename)
-        return None
-    else:
-        obj = s3.Object(s3_bucket, s3_key)
-        try:
-            obj = obj.get()
-        except ClientError as e:
-            if e.response['Error']['Code'] == 'InvalidRequestException':
-                print("Please check your query. Error message:")
-            else:
-                print('Please check your credentials including s3_bucket in config.ini file. Error message:')
-            print(e)
-            return None
-        df = pd.read_csv(obj['Body'])
-        return df
+from sroka.api.athena.athena_api_helpers import poll_status, download_file, return_on_exception
 
 
 def query_athena(query, filename=None):
@@ -82,10 +17,7 @@ def query_athena(query, filename=None):
     except (KeyError, NoOptionError) as e:
         print('No credentials were provided. Error message:')
         print(e)
-        if filename:
-            return None
-        else:
-            return pd.DataFrame([])
+        return return_on_exception(filename)
 
     session = boto3.Session(
         aws_access_key_id=key_id,
@@ -113,35 +45,26 @@ def query_athena(query, filename=None):
         else:
             print('Please check your credentials including s3_bucket in config.ini file. Error message:')
         print(e)
-        if filename:
-            return None
-        else:
-            return pd.DataFrame([])
+        return return_on_exception(filename)
+
     except EndpointConnectionError as e:
         print('Please check your credentials including aws_region in config.ini file and Internet connection.',
               'Error message:')
         print(e)
-        if filename:
-            return None
-        else:
-            return pd.DataFrame([])
+        return return_on_exception(filename)
+
     query_id = result['QueryExecutionId']
     result = poll_status(athena, query_id)
     if result is None:
-        if filename:
-            return None
-        else:
-            return pd.DataFrame([])
+        return return_on_exception(filename)
+
     elif result['QueryExecution']['Status']['State'] == 'SUCCEEDED':
         s3_key = query_id + '.csv'
         return download_file(s3, s3_bucket, s3_key, filename)
     else:
         print('Query did not succeed. Reason:')
         print(result['QueryExecution']['Status']['StateChangeReason'])
-        if filename:
-            return None
-        else:
-            return pd.DataFrame([])
+        return return_on_exception(filename)
 
 
 def done_athena(query_id, filename=None):
@@ -153,10 +76,7 @@ def done_athena(query_id, filename=None):
     except (KeyError, NoOptionError) as e:
         print('All or part of credentials were not provided. Please verify config.ini file. Error message:')
         print(e)
-        if filename:
-            return None
-        else:
-            return pd.DataFrame([])
+        return return_on_exception(filename)
 
     if s3_bucket.startswith('s3://'):
         s3_bucket = s3_bucket.replace('s3://', '')
@@ -171,14 +91,11 @@ def done_athena(query_id, filename=None):
                             region_name=region)
     result = poll_status(athena, query_id)
     if result is None:
-        if filename:
-            return None
-        else:
-            return pd.DataFrame([])
+        return return_on_exception(filename)
     if result['QueryExecution']['Status']['State'] == 'SUCCEEDED':
         s3_key = urlparse(result['QueryExecution']['ResultConfiguration']['OutputLocation']).path[1:]
         return download_file(s3, s3_bucket, s3_key, filename)
     else:
         print('Query did not succeed. Reason:')
         print(result['QueryExecution']['Status']['StateChangeReason'])
-        return pd.DataFrame([])
+        return return_on_exception(filename)

--- a/sroka/api/athena/athena_api.py
+++ b/sroka/api/athena/athena_api.py
@@ -17,20 +17,25 @@ def poll_status(session, _id):
         result = session.get_query_execution(
             QueryExecutionId=_id
         )
-    except ClientError:
-        print("Invalid query_id")
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'InvalidRequestException':
+            print("Please check your query_id. Error message:")
+        else:
+            print("ClientError. Error message:")
+        print(e)
         return None
-    except EndpointConnectionError:
-        print('Please check your credentials including aws_region in config.ini file')
+    except EndpointConnectionError as e:
+        print('Please check your credentials including aws_region in config.ini file and Internet connection.',
+              'Error message:')
+        print(e)
         return None
 
     state = result['QueryExecution']['Status']['State']
 
-    if state == 'SUCCEEDED':
-        return result
-    elif state == 'FAILED':
+    if state in ('SUCCEEDED', 'FAILED', 'CANCELLED'):
         return result
     else:
+        print('Waiting for {} query to end'.format(_id))
         raise Exception
 
 
@@ -38,11 +43,18 @@ def download_file(s3, s3_bucket, s3_key, filename):
     if filename:
         try:
             s3.Bucket(s3_bucket).download_file(s3_key, filename)
-        except FileNotFoundError:
-            print('File or folder not found.')
+        except FileNotFoundError as e:
+            print('File or folder not found. Error message:')
+            print(e)
             return None
-        except ClientError:
-            print('Please check your credentials including s3_bucket in config.ini file')
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'InvalidRequestException':
+                print("Please check your query. Error message:")
+            elif e.response['Error']['Code'] == '':
+                print('')
+            else:
+                print('Please check your credentials including s3_bucket in config.ini file. Error message:')
+            print(e)
             return None
         print('saved to ' + filename)
         return None
@@ -50,9 +62,13 @@ def download_file(s3, s3_bucket, s3_key, filename):
         obj = s3.Object(s3_bucket, s3_key)
         try:
             obj = obj.get()
-        except ClientError:
-            print('Please check your credentials including s3_bucket in config.ini file')
-            return pd.DataFrame([])
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'InvalidRequestException':
+                print("Please check your query. Error message:")
+            else:
+                print('Please check your credentials including s3_bucket in config.ini file. Error message:')
+            print(e)
+            return None
         df = pd.read_csv(obj['Body'])
         return df
 
@@ -63,9 +79,13 @@ def query_athena(query, filename=None):
         key_id = config.get_value('aws', 'aws_access_key_id')
         access_key = config.get_value('aws', 'aws_secret_access_key')
         region = config.get_value('aws', 'aws_region')
-    except (KeyError, NoOptionError):
-        print('No credentials were provided')
-        return pd.DataFrame([])
+    except (KeyError, NoOptionError) as e:
+        print('No credentials were provided. Error message:')
+        print(e)
+        if filename:
+            return None
+        else:
+            return pd.DataFrame([])
 
     session = boto3.Session(
         aws_access_key_id=key_id,
@@ -87,19 +107,41 @@ def query_athena(query, filename=None):
                 'OutputLocation': output_s3_bucket,
             }
         )
-    except ClientError:
-        print('Please check your credentials including s3_bucket in config.ini file')
-        return pd.DataFrame([])
-    except EndpointConnectionError:
-        print('Please check your credentials including aws_region in config.ini file')
-        return pd.DataFrame([])
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'InvalidRequestException':
+            print("Please check your query. Error message:")
+        else:
+            print('Please check your credentials including s3_bucket in config.ini file. Error message:')
+        print(e)
+        if filename:
+            return None
+        else:
+            return pd.DataFrame([])
+    except EndpointConnectionError as e:
+        print('Please check your credentials including aws_region in config.ini file and Internet connection.',
+              'Error message:')
+        print(e)
+        if filename:
+            return None
+        else:
+            return pd.DataFrame([])
     query_id = result['QueryExecutionId']
     result = poll_status(athena, query_id)
-    if result['QueryExecution']['Status']['State'] == 'SUCCEEDED':
+    if result is None:
+        if filename:
+            return None
+        else:
+            return pd.DataFrame([])
+    elif result['QueryExecution']['Status']['State'] == 'SUCCEEDED':
         s3_key = query_id + '.csv'
         return download_file(s3, s3_bucket, s3_key, filename)
     else:
-        print('Query did not succeed')
+        print('Query did not succeed. Reason:')
+        print(result['QueryExecution']['Status']['StateChangeReason'])
+        if filename:
+            return None
+        else:
+            return pd.DataFrame([])
 
 
 def done_athena(query_id, filename=None):
@@ -108,9 +150,14 @@ def done_athena(query_id, filename=None):
         key_id = config.get_value('aws', 'aws_access_key_id')
         access_key = config.get_value('aws', 'aws_secret_access_key')
         region = config.get_value('aws', 'aws_region')
-    except (KeyError, NoOptionError):
-        print('No credentials were provided')
-        return pd.DataFrame([])
+    except (KeyError, NoOptionError) as e:
+        print('All or part of credentials were not provided. Please verify config.ini file. Error message:')
+        print(e)
+        if filename:
+            return None
+        else:
+            return pd.DataFrame([])
+
     if s3_bucket.startswith('s3://'):
         s3_bucket = s3_bucket.replace('s3://', '')
 
@@ -124,9 +171,14 @@ def done_athena(query_id, filename=None):
                             region_name=region)
     result = poll_status(athena, query_id)
     if result is None:
-        return pd.DataFrame([])
+        if filename:
+            return None
+        else:
+            return pd.DataFrame([])
     if result['QueryExecution']['Status']['State'] == 'SUCCEEDED':
         s3_key = urlparse(result['QueryExecution']['ResultConfiguration']['OutputLocation']).path[1:]
         return download_file(s3, s3_bucket, s3_key, filename)
     else:
-        print('Query did not succeed')
+        print('Query did not succeed. Reason:')
+        print(result['QueryExecution']['Status']['StateChangeReason'])
+        return pd.DataFrame([])

--- a/sroka/api/athena/athena_api.py
+++ b/sroka/api/athena/athena_api.py
@@ -5,10 +5,22 @@ import boto3
 from botocore.exceptions import ClientError, EndpointConnectionError
 
 import sroka.config.config as config
-from sroka.api.athena.athena_api_helpers import poll_status, download_file, return_on_exception
+from sroka.api.athena.athena_api_helpers import poll_status, download_file, return_on_exception, \
+    input_check
 
 
 def query_athena(query, filename=None):
+
+    if not input_check(query, [str]):
+        return return_on_exception(filename)
+
+    if not input_check(filename, [str, type(None)]):
+        return return_on_exception(filename)
+
+    if filename == '':
+        print('Filename cannot be empty')
+        return return_on_exception(filename)
+
     try:
         s3_bucket = config.get_value('aws', 's3bucket_name')
         key_id = config.get_value('aws', 'aws_access_key_id')
@@ -68,6 +80,13 @@ def query_athena(query, filename=None):
 
 
 def done_athena(query_id, filename=None):
+
+    if not input_check(query_id, [str]):
+        return return_on_exception(filename)
+
+    if not input_check(filename, [str, type(None)]):
+        return return_on_exception(filename)
+
     try:
         s3_bucket = config.get_value('aws', 's3bucket_name')
         key_id = config.get_value('aws', 'aws_access_key_id')

--- a/sroka/api/athena/athena_api_helpers.py
+++ b/sroka/api/athena/athena_api_helpers.py
@@ -3,11 +3,19 @@ from botocore.exceptions import ClientError, EndpointConnectionError
 from retrying import retry
 
 
+def input_check(input_to_check, expected_types):
+    for expected_type in expected_types:
+        if type(input_to_check) == expected_type:
+            if expected_type == str and len(input_to_check) == 0:
+                print('Function input must be a nonempty string.')
+                return False
+            return True
+    print('Function input must be a string.')
+    return False
+
+
 def return_on_exception(filename):
-    if filename:
-        return None
-    else:
-        return pd.DataFrame([])
+    return None if filename else pd.DataFrame([])
 
 
 @retry(stop_max_attempt_number=10,
@@ -68,5 +76,10 @@ def download_file(s3, s3_bucket, s3_key, filename):
                 print('Please check your credentials including s3_bucket in config.ini file. Error message:')
             print(e)
             return None
-        df = pd.read_csv(obj['Body'])
+        try:
+            df = pd.read_csv(obj['Body'])
+        except ValueError as e:
+            print('Something went wrong with query output formatting. Error message:')
+            print(e)
+            return None
         return df

--- a/sroka/api/athena/athena_api_helpers.py
+++ b/sroka/api/athena/athena_api_helpers.py
@@ -1,0 +1,72 @@
+import pandas as pd
+from botocore.exceptions import ClientError, EndpointConnectionError
+from retrying import retry
+
+
+def return_on_exception(filename):
+    if filename:
+        return None
+    else:
+        return pd.DataFrame([])
+
+
+@retry(stop_max_attempt_number=10,
+       wait_exponential_multiplier=1 * 1000,
+       wait_exponential_max=10 * 60 * 1000)
+def poll_status(session, _id):
+    try:
+        result = session.get_query_execution(
+            QueryExecutionId=_id
+        )
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'InvalidRequestException':
+            print("Please check your query_id. Error message:")
+        else:
+            print("ClientError. Error message:")
+        print(e)
+        return None
+    except EndpointConnectionError as e:
+        print('Please check your credentials including aws_region in config.ini file and Internet connection.',
+              'Error message:')
+        print(e)
+        return None
+
+    state = result['QueryExecution']['Status']['State']
+
+    if state in ('SUCCEEDED', 'FAILED', 'CANCELLED'):
+        return result
+    else:
+        print('Waiting for {} query to end'.format(_id))
+        raise Exception
+
+
+def download_file(s3, s3_bucket, s3_key, filename):
+    if filename:
+        try:
+            s3.Bucket(s3_bucket).download_file(s3_key, filename)
+        except FileNotFoundError as e:
+            print('File or folder not found. Error message:')
+            print(e)
+            return None
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'InvalidRequestException':
+                print("Please check your query. Error message:")
+            else:
+                print('Please check your credentials including s3_bucket in config.ini file. Error message:')
+            print(e)
+            return None
+        print('saved to ' + filename)
+        return None
+    else:
+        obj = s3.Object(s3_bucket, s3_key)
+        try:
+            obj = obj.get()
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'InvalidRequestException':
+                print("Please check your query. Error message:")
+            else:
+                print('Please check your credentials including s3_bucket in config.ini file. Error message:')
+            print(e)
+            return None
+        df = pd.read_csv(obj['Body'])
+        return df

--- a/sroka/api/athena/athena_api_helpers.py
+++ b/sroka/api/athena/athena_api_helpers.py
@@ -15,7 +15,7 @@ def input_check(input_to_check, expected_types):
 
 
 def return_on_exception(filename):
-    return None if filename else pd.DataFrame([])
+    return None if filename or filename == '' else pd.DataFrame([])
 
 
 @retry(stop_max_attempt_number=10,


### PR DESCRIPTION
Goal of this PR: we have better error messages for Athena API.

AC:
* We always return pandas DataFrame if no filename is defined (even when errors occur)
* We always return None if filename is defined (even when errors occur)
* Printed messages are actionable

Use case for which wrong message was raised:

> 1. run query similar to one below in a cell (note missing quote on day value)
> 
> query = query_athena('''SELECT *
>                             FROM table_name
>                                 WHERE year = '2019'
>                                 AND month = '09' AND day = '07
>                                 limit 10''')
> 2. returns: Please check your credentials including s3_bucket in config.ini file
> 
> When the same query is run in Athena it throws an error line 3:60: no viable alternative at input '= '' (service: amazonathena; status code: 400; error code: invalidrequestexception; request id: 46d71f5e-ac75-4dab-a474-4c9541774386)
> 

TODO in future:
* We plan to add debug mode for all API connectors. If enabled Errors will be raised.