### PR TITLE
Make sroka work with Python version 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Package providing simple Python access to data in:
 * s3
 * MySQL
 
-Sroka library was checked to work for Python **>=3.6 <3.8**.
+Sroka library was checked to work for Python **>=3.5 <3.8**.
 
 ## Developers
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ google_api_python_client>=1.6.7
 google_auth_oauthlib>=0.2.0
 googleads>=14.1.0
 isort==4.3.9
+lxml<4.3;python_version<"3.6"
 mysql-connector-python==8.0.17
 numpy>=1.16.2
 pandas>=0.22.0

--- a/sroka/api/google_drive/README.md
+++ b/sroka/api/google_drive/README.md
@@ -3,7 +3,7 @@
 ## Methods
 
 
-### `google_drive_sheets_read(sheetname_id, sheet_range)`
+### `google_drive_sheets_read(sheetname_id, sheet_range, first_row_columns=True)`
 Read from existing google sheet
 
 

--- a/sroka/api/moat/moat_api.py
+++ b/sroka/api/moat/moat_api.py
@@ -54,8 +54,10 @@ def get_data_from_moat(moat_dict, database_name):
     resp = http.request('GET', 'https://api.moat.com/1/stats.json',
                         fields=moat_dict,
                         headers={'Authorization': auth_header})
-
-    data = json.loads(resp.data)
+    try:
+        data = json.loads(resp.data)
+    except TypeError:
+        data = json.loads(resp.data.decode('utf-8'))
 
     if 'error' in data.keys():
         print('Error: ' + data['error'])


### PR DESCRIPTION
AC:
* sroka works with Python 3.5

+ some cosmetic changes


Note: For Python 3.8 we need to wait for pyarrow to be compatible with Python 3.8