### PR TITLE
GAM report dimension attributes

### DIFF
--- a/sroka/api/google_ad_manager/README.md
+++ b/sroka/api/google_ad_manager/README.md
@@ -2,7 +2,7 @@
 
 ## Methods
 
-### `get_data_from_admanager(query, dimensions, columns, start_date, stop_date, custom_field_id, network_code)`
+### `get_data_from_admanager(query, dimensions, columns, start_date, stop_date, custom_field_id, dimension_attributes, network_code)`
 
 #### Arguments
 
@@ -13,7 +13,7 @@
 * dict `start_date` - obligatory
 * dict `stop_date` - obligatory
 * list `custom_field_id` -  list of ints, default=[], not obligatory  IMPORTANT: to use custom field id corresponding dimension is needed
-* list `dimension_attributes` -  list of strings, default=[], not obligatory  IMPORTANT: to use deimension attribute corresponding dimension is needed
+* list `dimension_attributes` -  list of strings, default=[], not obligatory  IMPORTANT: to use dimension attribute corresponding dimension is needed
 * int `network_code` - default value taken from config.ini file. If the same service account has access to more than one network, the default value can be overwritten with this argument.
 
 What is `custom_field_id` ?

--- a/sroka/api/google_ad_manager/README.md
+++ b/sroka/api/google_ad_manager/README.md
@@ -21,7 +21,7 @@ What is `custom_field_id` ?
 * To find id of custom field go to GAM dashboard -> Admin -> Global settings -> Custom Fields -> Choose Custom Field and id can be found in URL
 
 What are `dimension_attributes` ?
-* Dimension attributes provide additional fields associated with a dimension like start/end date, goal, pacing. These fields can be used to organize objects in reports.
+* Dimension attributes provide additional fields associated with a dimension like start/end date, goal, pacing. These fields can be used to organize objects in reports and get non-metrical informations regarding specific dimension.
 * List of the dimension atrributes can be found on [Google Ad Manager Help](https://support.google.com/admanager/answer/2875225?hl=en&ref_topic=7492017) or [GAM API documentation](https://developers.google.com/ad-manager/api/reference/v202011/ReportService.DimensionAttribute)
 
 

--- a/sroka/api/google_ad_manager/README.md
+++ b/sroka/api/google_ad_manager/README.md
@@ -21,7 +21,7 @@ What is `custom_field_id` ?
 * To find id of custom field go to GAM dashboard -> Admin -> Global settings -> Custom Fields -> Choose Custom Field and id can be found in URL
 
 What are `dimension_attributes` ?
-* Dimension attributes provides additional fields associated with a dimension like start/end date, goal, pacing. These fields can be used to organize objects in reports.
+* Dimension attributes provide additional fields associated with a dimension like start/end date, goal, pacing. These fields can be used to organize objects in reports.
 * List of the dimension atrributes can be found on [Google Ad Manager Help](https://support.google.com/admanager/answer/2875225?hl=en&ref_topic=7492017) or [GAM API documentation](https://developers.google.com/ad-manager/api/reference/v202011/ReportService.DimensionAttribute)
 
 

--- a/sroka/api/google_ad_manager/README.md
+++ b/sroka/api/google_ad_manager/README.md
@@ -13,13 +13,16 @@
 * dict `start_date` - obligatory
 * dict `stop_date` - obligatory
 * list `custom_field_id` -  list of ints, default=[], not obligatory  IMPORTANT: to use custom field id corresponding dimension is needed
+* list `dimension_attributes` -  list of strings, default=[], not obligatory  IMPORTANT: to use deimension attribute corresponding dimension is needed
 * int `network_code` - default value taken from config.ini file. If the same service account has access to more than one network, the default value can be overwritten with this argument.
 
 What is `custom_field_id` ?
 * Custom fields are additional fields that you can apply to orders, line items, and creatives. These fields can be used to organize objects in reports. You apply the field to a particular object by setting a value for it.
 * To find id of custom field go to GAM dashboard -> Admin -> Global settings -> Custom Fields -> Choose Custom Field and id can be found in URL
 
-
+What are `dimension_attributes` ?
+* Dimension attributes provides additional fields associated with a dimension like start/end date, goal, pacing. These fields can be used to organize objects in reports.
+* List of the dimension atrributes can be found on [Google Ad Manager Help](https://support.google.com/admanager/answer/2875225?hl=en&ref_topic=7492017) or [GAM API documentation](https://developers.google.com/ad-manager/api/reference/v202011/ReportService.DimensionAttribute)
 
 
 #### Returns
@@ -41,6 +44,7 @@ year = '2017'
 # Data from GAM - orders
 query = "WHERE CUSTOM_TARGETING_VALUE_ID=12345"
 dimensions = ['DATE', 'LINE_ITEM_NAME']
+dimension_attributes = ['LINE_ITEM_GOAL_QUANTITY']
 custom_field_id = [54321]
 columns = ['TOTAL_INVENTORY_LEVEL_IMPRESSIONS', 
            'TOTAL_ACTIVE_VIEW_MEASURABLE_IMPRESSIONS',
@@ -52,6 +56,6 @@ stop_date = {'year': year,
              'month': end_month,
              'day': end_day}
 
-data = get_data_from_admanager(query, dimensions, columns, start_date, stop_date, custom_field_id, network_code=1234)
+data = get_data_from_admanager(query, dimensions, columns, start_date, stop_date, custom_field_id, dimension_attributes, network_code=1234)
 
 ```

--- a/sroka/api/google_ad_manager/README.md
+++ b/sroka/api/google_ad_manager/README.md
@@ -21,7 +21,7 @@ What is `custom_field_id` ?
 * To find id of custom field go to GAM dashboard -> Admin -> Global settings -> Custom Fields -> Choose Custom Field and id can be found in URL
 
 What are `dimension_attributes` ?
-* Dimension attributes provide additional fields associated with a dimension like start/end date, goal, pacing. These fields can be used to organize objects in reports and get non-metrical informations regarding specific dimension.
+* Dimension attributes provide additional fields associated with a dimension like start/end date, goal, pacing. These fields can be used to organize objects in reports and get non-metrical information regarding specific dimension.
 * List of the dimension atrributes can be found on [Google Ad Manager Help](https://support.google.com/admanager/answer/2875225?hl=en&ref_topic=7492017) or [GAM API documentation](https://developers.google.com/ad-manager/api/reference/v202011/ReportService.DimensionAttribute)
 
 
@@ -56,6 +56,6 @@ stop_date = {'year': year,
              'month': end_month,
              'day': end_day}
 
-data = get_data_from_admanager(query, dimensions, columns, start_date, stop_date, custom_field_id, dimension_attributes, network_code=1234)
+data = get_data_from_admanager(query, dimensions, columns, start_date, stop_date, custom_field_id=custom_field_id, dimension_attributes=dimension_attributes, network_code=1234)
 
 ```

--- a/sroka/api/google_ad_manager/gam_api.py
+++ b/sroka/api/google_ad_manager/gam_api.py
@@ -16,11 +16,14 @@ except (KeyError, NoOptionError):
     APPLICATION_NAME = 'Application name'
 
 
-def get_data_from_admanager(query, dimensions, columns, start_date, end_date, custom_field_id=None, network_code=None):
+def get_data_from_admanager(query, dimensions, columns, start_date, end_date, custom_field_id=None, dimension_attributes=None, network_code=None):
 
     if not custom_field_id:
         custom_field_id = []
-
+    
+    if not dimension_attributes:
+        dimension_attributes = []
+    
     if not network_code:
         try:
             network_code = config.get_value('google_ad_manager', 'network_code')
@@ -47,6 +50,7 @@ def get_data_from_admanager(query, dimensions, columns, start_date, end_date, cu
           'statement': filter_statement,
           'columns': columns,
           'customFieldIds': custom_field_id,
+          'dimensionAttributes': dimension_attributes,
           'dateRangeType': 'CUSTOM_DATE',
           'startDate': start_date,
           'endDate': end_date,


### PR DESCRIPTION
Dimension attributes field stores useful informations regarding dimensions, which cannot be obtain in other way. 
For example goal quantity.

Using it also simplifies pulling informations that can be got via GAM API, but requires connecting with other services and combining the results with ones provided by Sroka. 

For example, to obtain order's trafficker we can either use dimension attribute or pull trafficker's and order's id from Order Service, merge it with trafficker's name pulled via User Service and then match it to specific order ids provided by the report.