### PR TITLE
Gam users

### DIFF
--- a/sroka/api/google_ad_manager/README.md
+++ b/sroka/api/google_ad_manager/README.md
@@ -41,7 +41,7 @@ start_month = '08'
 end_month = '08'
 year = '2017'
 
-# Data from GAM - orders
+# Data from GAM - report
 query = "WHERE CUSTOM_TARGETING_VALUE_ID=12345"
 dimensions = ['DATE', 'LINE_ITEM_NAME']
 dimension_attributes = ['LINE_ITEM_GOAL_QUANTITY']
@@ -60,7 +60,7 @@ data = get_data_from_admanager(query, dimensions, columns, start_date, stop_date
 
 ```
 
-### `def get_users_from_admanager(query, dimensions, network_code)`
+### `get_users_from_admanager(query, dimensions, network_code)`
 
 #### Arguments
 
@@ -78,7 +78,7 @@ data = get_data_from_admanager(query, dimensions, columns, start_date, stop_date
 ```python
 from sroka.api.google_ad_manager.gam_api import get_users_from_admanager
 
-# Data from GAM - orders
+# Data from GAM - user list
 query = "WHERE roleName IN ('Administrator')"
 dimensions = ['id', 'name']
 

--- a/sroka/api/google_ad_manager/README.md
+++ b/sroka/api/google_ad_manager/README.md
@@ -59,3 +59,29 @@ stop_date = {'year': year,
 data = get_data_from_admanager(query, dimensions, columns, start_date, stop_date, custom_field_id=custom_field_id, dimension_attributes=dimension_attributes, network_code=1234)
 
 ```
+
+### `def get_users_from_admanager(query, dimensions, network_code)`
+
+#### Arguments
+
+
+* string `query` - obligatory (does not require WHERE clause)
+* list `dimensions` - obligatory IMPORTANT: roleName is readonly attribute
+* int `network_code` - default value taken from config.ini file. If the same service account has access to more than one network, the default value can be overwritten with this argument.
+
+#### Returns
+
+* pandas.DataFrame
+
+## Example usage
+
+```python
+from sroka.api.google_ad_manager.gam_api import get_users_from_admanager
+
+# Data from GAM - orders
+query = "WHERE roleName IN ('Administrator')"
+dimensions = ['id', 'name']
+
+data = get_users_from_admanager(query, dimensions, network_code=1234)
+
+```

--- a/sroka/api/google_ad_manager/gam_api.py
+++ b/sroka/api/google_ad_manager/gam_api.py
@@ -20,10 +20,10 @@ def get_data_from_admanager(query, dimensions, columns, start_date, end_date, cu
 
     if not custom_field_id:
         custom_field_id = []
-    
+
     if not dimension_attributes:
         dimension_attributes = []
-    
+
     if not network_code:
         try:
             network_code = config.get_value('google_ad_manager', 'network_code')
@@ -95,18 +95,17 @@ def get_data_from_admanager(query, dimensions, columns, start_date, end_date, cu
 
 
 def get_users_from_admanager(query, dimensions, network_code=None):
-    
+
     user_df = pd.DataFrame()
-    
+
     dimensions_df = pd.DataFrame()
-        
-    #.Where() handles filtering with admanager method, while statement_query handles queries with WHERE clause
-    
-    statement_query = query.replace("WHERE ", "")
-    
-    statement = (ad_manager.StatementBuilder()
-               .Where((statement_query)))
-    
+
+    # .Where() handles filtering with admanager method, while statement_query handles queries with WHERE clause
+
+    statement_query = query.upper().replace("WHERE ", "")
+
+    statement = (ad_manager.StatementBuilder().Where((statement_query)))
+
     if not network_code:
         try:
             network_code = config.get_value('google_ad_manager', 'network_code')
@@ -121,36 +120,38 @@ def get_users_from_admanager(query, dimensions, network_code=None):
 
     # Initialize the GAM client.
     gam_client = ad_manager.AdManagerClient.LoadFromString(yaml_string)
-    
-    user_service = gam_client.GetService('UserService')
-    
-    
-    try:
 
+    user_service = gam_client.GetService('UserService')
+
+    try:
         while True:
             response = user_service.getUsersByStatement(statement.ToStatement())
             if 'results' in response and len(response['results']):
-              for user in response['results']:
+                for user in response['results']:
 
-                for dimension in dimensions:
-                    dimension_value = [user[dimension]]
-                    dimensions_df[dimension] = dimension_value
+                    for dimension in dimensions:
+                        try:
+                            dimension_value = [user[dimension]]
+                            dimensions_df[dimension] = dimension_value
+                        except KeyError as e:
+                            print('Failed to generate user list. Incorrect dimension: {}'.format(e))
+                            return    
 
-                user_df = user_df.append(dimensions_df, sort=False)
-              statement.offset += statement.limit
+                    user_df = user_df.append(dimensions_df, sort=False)
+                statement.offset += statement.limit
             else:
-              break
+                break
         return user_df
-        
+
     except errors.GoogleAdsServerFault as e:
         if 'AuthenticationError.NETWORK_NOT_FOUND' in str(e):
             print('Provided network code was not found.')
         elif 'AuthenticationError.NETWORK_CODE_REQUIRED' in str(e):
             print('Default value of network code is missing from ', config.default_config_filepath)
         else:
-            print('Failed to generate report. Error was: {}'.format(e))
+            print('Failed to generate user list. Error was: {}'.format(e))
         return
 
     except errors.AdManagerReportError as e:
-        print('Failed to generate report. Error was: {}'.format(e))
+        print('Failed to generate user list. Error was: {}'.format(e))
         return


### PR DESCRIPTION
Docs: https://developers.google.com/ad-manager/api/reference/v202011/UserService.User

get_users_from_admanager function pulls information about GAM users. 
It can be used for further campaign filtering, especially when there are custom roles within network.

Few notes:

- query can be handled both with and without WHERE clause
- results of the query are appending to df line after line, and therefore all lines in final df have index 0
- according to doc, id, name, etc are not exactly dimensions, but I kept this name for consistency across functions