### PR TITLE
GAM Companies

### DIFF
--- a/sroka/api/google_ad_manager/README.md
+++ b/sroka/api/google_ad_manager/README.md
@@ -66,7 +66,7 @@ data = get_data_from_admanager(query, dimensions, columns, start_date, stop_date
 
 
 * string `query` - obligatory (does not require WHERE clause)
-* list `dimensions` - obligatory IMPORTANT: roleName is readonly attribute
+* list `dimensions` - obligatory IMPORTANT: roleName is a readonly attribute
 * int `network_code` - default value taken from config.ini file. If the same service account has access to more than one network, the default value can be overwritten with this argument.
 
 #### Returns
@@ -83,5 +83,31 @@ query = "WHERE roleName IN ('Administrator')"
 dimensions = ['id', 'name']
 
 data = get_users_from_admanager(query, dimensions, network_code=1234)
+
+```
+
+### `get_companies_from_admanager(query, dimensions, network_code)`
+
+#### Arguments
+
+
+* string `query` - obligatory (does not require WHERE clause)
+* list `dimensions` - obligatory
+* int `network_code` - default value taken from config.ini file. If the same service account has access to more than one network, the default value can be overwritten with this argument.
+
+#### Returns
+
+* pandas.DataFrame
+
+## Example usage
+
+```python
+from sroka.api.google_ad_manager.gam_api import get_companies_from_admanager
+
+# Data from GAM - company list
+query = "WHERE type IN ('Advertiser')"
+dimensions = ['id', 'name']
+
+data = get_companies_from_admanager(query, dimensions, network_code=1234)
 
 ```

--- a/sroka/api/google_ad_manager/gam_api.py
+++ b/sroka/api/google_ad_manager/gam_api.py
@@ -157,6 +157,7 @@ def get_users_from_admanager(query, dimensions, network_code=None):
         print('Failed to generate user list. Error was: {}'.format(e))
         return
 
+
 def get_companies_from_admanager(query, dimensions, network_code=None):
 
     company_df = pd.DataFrame()
@@ -198,7 +199,7 @@ def get_companies_from_admanager(query, dimensions, network_code=None):
                             dimensions_df[dimension] = dimension_value
                         except KeyError as e:
                             print('Failed to generate company list. Incorrect dimension: {}'.format(e))
-                            return    
+                            return
 
                     company_df = company_df.append(dimensions_df, sort=False)
                 statement.offset += statement.limit
@@ -217,4 +218,4 @@ def get_companies_from_admanager(query, dimensions, network_code=None):
 
     except errors.AdManagerReportError as e:
         print('Failed to generate company list. Error was: {}'.format(e))
-        return    
+        return

--- a/sroka/api/google_ad_manager/gam_api.py
+++ b/sroka/api/google_ad_manager/gam_api.py
@@ -16,6 +16,24 @@ except (KeyError, NoOptionError):
     APPLICATION_NAME = 'Application name'
 
 
+def init_gam_connection(network_code=None):
+
+    if not network_code:
+        try:
+            network_code = config.get_value('google_ad_manager', 'network_code')
+        except (KeyError, NoOptionError):
+            print('No network code was provided')
+            return pd.DataFrame([])
+    yaml_string = "ad_manager: " + "\n" + \
+                  "  application_name: " + APPLICATION_NAME + "\n" + \
+                  "  network_code: " + str(network_code) + "\n" + \
+                  "  path_to_private_key_file: " + KEY_FILE + "\n"
+
+    # Initialize the GAM client.
+    gam_client = ad_manager.AdManagerClient.LoadFromString(yaml_string)
+    return gam_client
+
+
 def get_data_from_admanager(query, dimensions, columns, start_date, end_date, custom_field_id=None,
                             dimension_attributes=None, network_code=None):
 
@@ -25,20 +43,7 @@ def get_data_from_admanager(query, dimensions, columns, start_date, end_date, cu
     if not dimension_attributes:
         dimension_attributes = []
 
-    if not network_code:
-        try:
-            network_code = config.get_value('google_ad_manager', 'network_code')
-        except (KeyError, NoOptionError):
-            print('No network code was provided')
-            return pd.DataFrame([])
-
-    yaml_string = "ad_manager: " + "\n" + \
-        "  application_name: " + APPLICATION_NAME + "\n" + \
-        "  network_code: " + str(network_code) + "\n" + \
-        "  path_to_private_key_file: " + KEY_FILE + "\n"
-
-    # Initialize the GAM client.
-    gam_client = ad_manager.AdManagerClient.LoadFromString(yaml_string)
+    gam_client = init_gam_connection(network_code)
 
     # Create statement object to filter for an order.
 
@@ -105,22 +110,9 @@ def get_users_from_admanager(query, dimensions, network_code=None):
 
     statement_query = query.upper().replace("WHERE ", "")
 
-    statement = (ad_manager.StatementBuilder().Where((statement_query)))
+    statement = ad_manager.StatementBuilder().Where(statement_query)
 
-    if not network_code:
-        try:
-            network_code = config.get_value('google_ad_manager', 'network_code')
-        except (KeyError, NoOptionError):
-            print('No network code was provided')
-            return pd.DataFrame([])
-
-    yaml_string = "ad_manager: " + "\n" + \
-        "  application_name: " + APPLICATION_NAME + "\n" + \
-        "  network_code: " + str(network_code) + "\n" + \
-        "  path_to_private_key_file: " + KEY_FILE + "\n"
-
-    # Initialize the GAM client.
-    gam_client = ad_manager.AdManagerClient.LoadFromString(yaml_string)
+    gam_client = init_gam_connection(network_code)
 
     user_service = gam_client.GetService('UserService')
 
@@ -168,22 +160,9 @@ def get_companies_from_admanager(query, dimensions, network_code=None):
 
     statement_query = query.upper().replace("WHERE ", "")
 
-    statement = (ad_manager.StatementBuilder().Where((statement_query)))
+    statement = ad_manager.StatementBuilder().Where(statement_query)
 
-    if not network_code:
-        try:
-            network_code = config.get_value('google_ad_manager', 'network_code')
-        except (KeyError, NoOptionError):
-            print('No network code was provided')
-            return pd.DataFrame([])
-
-    yaml_string = "ad_manager: " + "\n" + \
-        "  application_name: " + APPLICATION_NAME + "\n" + \
-        "  network_code: " + str(network_code) + "\n" + \
-        "  path_to_private_key_file: " + KEY_FILE + "\n"
-
-    # Initialize the GAM client.
-    gam_client = ad_manager.AdManagerClient.LoadFromString(yaml_string)
+    gam_client = init_gam_connection(network_code)
 
     company_service = gam_client.GetService('CompanyService')
 

--- a/sroka/api/google_ad_manager/gam_api.py
+++ b/sroka/api/google_ad_manager/gam_api.py
@@ -7,6 +7,8 @@ from googleads import ad_manager, errors
 
 import sroka.config.config as config
 
+# import variable_validators as validator
+
 KEY_FILE = config.get_file_path('google_ad_manager')
 
 # GAM API information.
@@ -16,8 +18,31 @@ except (KeyError, NoOptionError):
     APPLICATION_NAME = 'Application name'
 
 
-def init_gam_connection(network_code=None):
+def dict_type_checker(dict_argument, argument_name):
+    if dict_argument and type(dict_argument) != dict:
+        print(f"""{argument_name} needs to be a dict""")
+        return "Incorrect type"
 
+
+def int_type_checker(int_argument, argument_name):
+    if int_argument and type(int_argument) != int:
+        print(f"""{argument_name} needs to be an integer""")
+        return "Incorrect type"
+
+
+def list_type_checker(list_argument, argument_name):
+    if list_argument and type(list_argument) != list:
+        print(f"""{argument_name} needs to be a list""")
+        return "Incorrect type"
+
+
+def str_type_checker(str_argument, argument_name):
+    if str_argument and type(str_argument) != str:
+        print(f"""{argument_name} needs to be a string""")
+        return "Incorrect type"
+
+
+def init_gam_connection(network_code=None):
     if not network_code:
         try:
             network_code = config.get_value('google_ad_manager', 'network_code')
@@ -36,12 +61,23 @@ def init_gam_connection(network_code=None):
 
 def get_data_from_admanager(query, dimensions, columns, start_date, end_date, custom_field_id=None,
                             dimension_attributes=None, network_code=None):
-
     if not custom_field_id:
         custom_field_id = []
 
     if not dimension_attributes:
         dimension_attributes = []
+
+    list_of_types = [str_type_checker(query, "query"),
+                     list_type_checker(dimensions, "dimensions"),
+                     list_type_checker(columns, "columns"),
+                     dict_type_checker(start_date, "start_date"),
+                     dict_type_checker(end_date, "end_date"),
+                     list_type_checker(custom_field_id, "custom_field_id"),
+                     list_type_checker(dimension_attributes, "dimmension_attributes"),
+                     int_type_checker(network_code, "network_code")]
+
+    if "Incorrect type" in list_of_types:
+        return
 
     gam_client = init_gam_connection(network_code)
 
@@ -51,17 +87,17 @@ def get_data_from_admanager(query, dimensions, columns, start_date, end_date, cu
 
     # Create report job.
     report_job = {
-      'reportQuery': {
-          'dimensions': dimensions,
-          'statement': filter_statement,
-          'columns': columns,
-          'customFieldIds': custom_field_id,
-          'dimensionAttributes': dimension_attributes,
-          'dateRangeType': 'CUSTOM_DATE',
-          'startDate': start_date,
-          'endDate': end_date,
-          'adUnitView': "FLAT"
-      }
+        'reportQuery': {
+            'dimensions': dimensions,
+            'statement': filter_statement,
+            'columns': columns,
+            'customFieldIds': custom_field_id,
+            'dimensionAttributes': dimension_attributes,
+            'dateRangeType': 'CUSTOM_DATE',
+            'startDate': start_date,
+            'endDate': end_date,
+            'adUnitView': "FLAT"
+        }
     }
 
     report_downloader = gam_client.GetDataDownloader()
@@ -101,6 +137,12 @@ def get_data_from_admanager(query, dimensions, columns, start_date, end_date, cu
 
 
 def get_users_from_admanager(query, dimensions, network_code=None):
+    list_of_types = [str_type_checker(query, "query"),
+                     list_type_checker(dimensions, "dimensions"),
+                     int_type_checker(network_code, "network_code")]
+
+    if "Incorrect type" in list_of_types:
+        return
 
     user_df = pd.DataFrame()
 
@@ -151,6 +193,12 @@ def get_users_from_admanager(query, dimensions, network_code=None):
 
 
 def get_companies_from_admanager(query, dimensions, network_code=None):
+    list_of_types = [str_type_checker(query, "query"),
+                     list_type_checker(dimensions, "dimensions"),
+                     int_type_checker(network_code, "network_code")]
+
+    if "Incorrect type" in list_of_types:
+        return
 
     company_df = pd.DataFrame()
 

--- a/sroka/api/google_ad_manager/gam_api.py
+++ b/sroka/api/google_ad_manager/gam_api.py
@@ -18,28 +18,48 @@ except (KeyError, NoOptionError):
     APPLICATION_NAME = 'Application name'
 
 
-def dict_type_checker(dict_argument, argument_name):
-    if dict_argument and type(dict_argument) != dict:
-        print(f"""{argument_name} needs to be a dict""")
-        return "Incorrect type"
+def dict_type_checker(dict_argument, argument_name, mandatory=True):
+    if mandatory:
+        if type(dict_argument) != dict:
+            print(f"""{argument_name} needs to be a dict""")
+            return "Incorrect type"
+    else:
+        if dict_argument and type(dict_argument) != dict:
+            print(f"""{argument_name} needs to be a dict""")
+            return "Incorrect type"
 
 
-def int_type_checker(int_argument, argument_name):
-    if int_argument and type(int_argument) != int:
-        print(f"""{argument_name} needs to be an integer""")
-        return "Incorrect type"
+def int_type_checker(int_argument, argument_name, mandatory=True):
+    if mandatory:
+        if type(int_argument) != int:
+            print(f"""{argument_name} needs to be an integer""")
+            return "Incorrect type"
+    else:
+        if int_argument and type(int_argument) != int:
+            print(f"""{argument_name} needs to be an integer""")
+            return "Incorrect type"
 
 
-def list_type_checker(list_argument, argument_name):
-    if list_argument and type(list_argument) != list:
-        print(f"""{argument_name} needs to be a list""")
-        return "Incorrect type"
+def list_type_checker(list_argument, argument_name, mandatory=True):
+    if mandatory:
+        if type(list_argument) != list:
+            print(f"""{argument_name} needs to be a list""")
+            return "Incorrect type"
+    else:
+        if list_argument and type(list_argument) != list:
+            print(f"""{argument_name} needs to be a list""")
+            return "Incorrect type"
 
 
-def str_type_checker(str_argument, argument_name):
-    if str_argument and type(str_argument) != str:
-        print(f"""{argument_name} needs to be a string""")
-        return "Incorrect type"
+def str_type_checker(str_argument, argument_name, mandatory=True):
+    if mandatory:
+        if type(str_argument) != str:
+            print(f"""{argument_name} needs to be a string""")
+            return "Incorrect type"
+    else:
+        if str_argument and type(str_argument) != str:
+            print(f"""{argument_name} needs to be a string""")
+            return "Incorrect type"
 
 
 def init_gam_connection(network_code=None):
@@ -72,9 +92,9 @@ def get_data_from_admanager(query, dimensions, columns, start_date, end_date, cu
                      list_type_checker(columns, "columns"),
                      dict_type_checker(start_date, "start_date"),
                      dict_type_checker(end_date, "end_date"),
-                     list_type_checker(custom_field_id, "custom_field_id"),
-                     list_type_checker(dimension_attributes, "dimmension_attributes"),
-                     int_type_checker(network_code, "network_code")]
+                     list_type_checker(custom_field_id, "custom_field_id", False),
+                     list_type_checker(dimension_attributes, "dimmension_attributes", False),
+                     int_type_checker(network_code, "network_code", False)]
 
     if "Incorrect type" in list_of_types:
         return
@@ -139,7 +159,7 @@ def get_data_from_admanager(query, dimensions, columns, start_date, end_date, cu
 def get_users_from_admanager(query, dimensions, network_code=None):
     list_of_types = [str_type_checker(query, "query"),
                      list_type_checker(dimensions, "dimensions"),
-                     int_type_checker(network_code, "network_code")]
+                     int_type_checker(network_code, "network_code", False)]
 
     if "Incorrect type" in list_of_types:
         return
@@ -195,7 +215,7 @@ def get_users_from_admanager(query, dimensions, network_code=None):
 def get_companies_from_admanager(query, dimensions, network_code=None):
     list_of_types = [str_type_checker(query, "query"),
                      list_type_checker(dimensions, "dimensions"),
-                     int_type_checker(network_code, "network_code")]
+                     int_type_checker(network_code, "network_code", False)]
 
     if "Incorrect type" in list_of_types:
         return


### PR DESCRIPTION
Docs: https://developers.google.com/ad-manager/api/reference/v202011/CompanyService

get_companies_from_admanager function pulls information about GAM companies (for example Advertisers).
It can be used for further campaign filtering. Companies filter exists in report function, however I've seen on a few cases that prefiltering with other functions and using its results in report query can shorten run time of the whole code.