### PR TITLE
Bump googleads floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Check style with flake8:
 flake8 .
 ```
 
+Please target Pull Requests against `dev` branch.
 
 ## Installation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ google-auth-httplib2>=0.0.3
 google_api_python_client>=1.6.7
 google_auth_oauthlib>=0.2.0
 google-cloud-bigquery>=1.24.0
-googleads>=24.0.0
+googleads>=28.0.0
 isort==4.3.9
 lxml<4.3;python_version<"3.6"
 mysql-connector-python==8.0.17


### PR DESCRIPTION
googleads floor is too low - you cannot use it below 25.0.0, because all available API versions in this lib are sunsunset in the lower versions.

This floor should work till May 2022
https://webcache.googleusercontent.com/search?q=cache%3AnAu6cbUjLzQJ%3Ahttps%3A%2F%2Fdevelopers.google.com%2Fad-manager%2Fapi%2Fdeprecation%20&cd=2&hl=en&ct=clnk&gl=pl

---
**Afterwards googleads has to be replaced with google-ads**: https://ads-developers.googleblog.com/2021/04/upgrade-to-google-ads-api-from-adwords.html