### PR TITLE
DE- 8213 | Bump googleads, urlib, supported Python versions; release as sroka 0.0.8

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,6 @@
 # the repo. Unless a later match takes precedence,
 # @martynaut and @dorotamierzwa will be requested for
 # review when someone opens a pull request.
-*       @martynaut @dorotamierzwa
+*       @martynaut
 *       @Wikia/adeng
 *       @Wikia/data-engineering

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,3 +3,5 @@
 # @martynaut and @dorotamierzwa will be requested for
 # review when someone opens a pull request.
 *       @martynaut @dorotamierzwa
+*       @Wikia/adeng
+*       @Wikia/data-engineering

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Package providing simple Python access to data in:
 * MySQL
 * neo4j
 
-Sroka library was checked to work for Python **3.7, 3.8 and 3.9**.
+Sroka library was checked to work for Python **>=3.8, <=3.11**.
 
 ## Developers
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ google-auth-httplib2>=0.0.3
 google_api_python_client>=1.6.7
 google_auth_oauthlib>=0.2.0
 google-cloud-bigquery>=1.24.0
-googleads>=29.0.0
+googleads>=40.0.0
 isort==4.3.9
 lxml>=4.6.5
 mysql-connector-python==8.0.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ pyarrow>=0.11.1
 qds_sdk>=1.10.1
 requests>=2.20
 retrying>=1.3.3
-urllib3>=1.26.5
+urllib3>=1.26.18
 py2neo>=4.2.0
 db-dtypes

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt") as f:
 
 setuptools.setup(
     name="sroka",
-    version="0.0.7",
+    version="0.0.8",
     author="Ad Engineering FANDOM",
     author_email="murbanek@fandom.com",
     description="Package for access GA, GAM, MOAT, Qubole, Athena, S3, Rubicon APIs, BigQuery, MySQL",


### PR DESCRIPTION
- Bump googleads to newest version, so installs of sroka by default have valid googleads library 
```
Googleads 29.0 is no longer supported
[ApiVersionError.UPDATE_TO_NEWER_VERSION @ version; trigger:'Version v202211 was deprecated and is now disabled. Please check the DoubleClick for Publishers blog for more information or contact us via the support forum.']
```

-  Bump urllib due to CVEs issued for lower versions
https://devhub.checkmarx.com/cve-details/CVE-2023-43804/
https://devhub.checkmarx.com/cve-details/CVE-2023-45803/

- Drop support for Python 3.7 (EOL), tested with Python 3.7 and 3.11 by running [Test Notebook](https://github.com/Wikia/sroka/blob/81d49caf2228315bfad32bada00d33f0e6160e52/Test%20APIs.ipynb)

- Update CODEOWNERS

- Release as sroka 0.0.8