### PR TITLE
GAM REST API for private auctions and private auction deals

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 boto3>=1.9.19
 botocore>=1.12.19
 flake8==3.7.7
+google-auth>=2.0.0
 google-auth-httplib2>=0.0.3
 google_api_python_client>=1.6.7
 google_auth_oauthlib>=0.2.0

--- a/sroka/api/google_ad_manager/README.md
+++ b/sroka/api/google_ad_manager/README.md
@@ -1,5 +1,3 @@
-from sroka_internal_tests.google_ad_manager_tests import columns_to_keep
-
 # GAM API
 
 ## Methods
@@ -143,4 +141,112 @@ columns_to_keep = ['id', 'parentId', 'hasChildren', 'adUnitDetails', 'adUnitCode
 
 data = get_service_data_from_admanager(service, filter_text, network_code=1234)
 
+```
+
+---
+
+## REST (Beta) API
+
+The REST API functions live in `gam_rest_api.py` and use the same `ad_manager.json` service account key and `network_code` from `config.ini` as the SOAP functions above. No additional configuration is required.
+
+### `get_resource_from_admanager(resource, filter_str, page_size, order_by, columns_to_keep, network_code)`
+
+Generic function that fetches any supported REST resource. Handles pagination automatically via `nextPageToken`.
+
+#### Arguments
+
+* string `resource` - obligatory. Must be a key in the resource map. Supported values:
+  * `'PrivateAuction'`
+  * `'PrivateAuctionDeal'`
+* string `filter_str` - optional. Filter expression in GAM REST filter syntax, e.g. `"displayName = 'My Auction'"`.
+* int `page_size` - optional. Items per page, max 1000. Default: 1000.
+* string `order_by` - optional. Ordering expression, e.g. `'displayName ASC'`.
+* list `columns_to_keep` - optional. List of column names to include in the output DataFrame. If None, all columns are returned.
+* int/str `network_code` - optional. Default value taken from `config.ini`. Can be overwritten if the service account has access to more than one network.
+
+#### Returns
+
+* pandas.DataFrame
+
+#### Example usage
+
+```python
+from sroka.api.google_ad_manager.gam_rest_api import get_resource_from_admanager
+
+data = get_resource_from_admanager(
+    resource='PrivateAuction',
+    filter_str="displayName = 'My Auction'",
+    columns_to_keep=['name', 'displayName'],
+    network_code=1234,
+)
+```
+
+---
+
+### `get_private_auctions_from_admanager(filter_str, page_size, order_by, columns_to_keep, network_code)`
+
+Fetches Private Auctions from the GAM REST (Beta) API.
+
+API reference: [networks.privateAuctions](https://developers.google.com/ad-manager/api/beta/reference/rest/v1/networks.privateAuctions)
+
+#### Arguments
+
+* string `filter_str` - optional. Filter expression, e.g. `"displayName = 'My Auction'"`.
+* int `page_size` - optional. Items per page, max 1000. Default: 1000.
+* string `order_by` - optional. Ordering expression, e.g. `'displayName ASC'`.
+* list `columns_to_keep` - optional. List of column names to include in the output DataFrame. If None, all columns are returned.
+* int/str `network_code` - optional. Default value taken from `config.ini`.
+
+#### Returns
+
+* pandas.DataFrame
+
+#### Example usage
+
+```python
+from sroka.api.google_ad_manager.gam_rest_api import get_private_auctions_from_admanager
+
+# All private auctions
+data = get_private_auctions_from_admanager(network_code=1234)
+
+# With filtering and column selection
+data = get_private_auctions_from_admanager(
+    filter_str="displayName = 'My Auction'",
+    columns_to_keep=['name', 'displayName'],
+    network_code=1234,
+)
+```
+
+---
+
+### `get_private_auction_deals_from_admanager(filter_str, page_size, order_by, columns_to_keep, network_code)`
+
+Fetches Private Auction Deals from the GAM REST (Beta) API.
+
+API reference: [networks.privateAuctionDeals](https://developers.google.com/ad-manager/api/beta/reference/rest/v1/networks.privateAuctionDeals)
+
+#### Arguments
+
+* string `filter_str` - optional. Filter expression, e.g. `"status = 'ACTIVE'"`.
+* int `page_size` - optional. Items per page, max 1000. Default: 1000.
+* string `order_by` - optional. Ordering expression, e.g. `'createTime DESC'`.
+* list `columns_to_keep` - optional. List of column names to include in the output DataFrame. If None, all columns are returned.
+* int/str `network_code` - optional. Default value taken from `config.ini`.
+
+#### Returns
+
+* pandas.DataFrame
+
+#### Example usage
+
+```python
+from sroka.api.google_ad_manager.gam_rest_api import get_private_auction_deals_from_admanager
+
+# All active deals with selected columns
+data = get_private_auction_deals_from_admanager(
+    filter_str="status = 'ACTIVE'",
+    order_by='createTime DESC',
+    columns_to_keep=['name', 'status', 'buyerAccountId', 'floorPrice'],
+    network_code=1234,
+)
 ```

--- a/sroka/api/google_ad_manager/gam_rest_api.py
+++ b/sroka/api/google_ad_manager/gam_rest_api.py
@@ -1,0 +1,187 @@
+from configparser import NoOptionError
+
+import pandas as pd
+from google.auth.transport.requests import AuthorizedSession
+from google.oauth2 import service_account
+
+import sroka.config.config as config
+
+GAM_REST_BASE_URL = 'https://admanager.googleapis.com/v1'
+GAM_REST_SCOPE = 'https://www.googleapis.com/auth/admanager'
+GAM_REST_DEFAULT_PAGE_SIZE = 1000
+
+KEY_FILE = config.get_file_path('google_ad_manager')
+
+
+def init_gam_rest_connection(network_code=None):
+    """
+    Creates an authenticated session for the GAM REST (Beta) API.
+
+    Reuses the same service account key file as the SOAP connection
+    (ad_manager.json) and the same network_code from config.ini.
+
+    Args:
+        network_code (int|str): GAM network code. Falls back to config.ini.
+
+    Returns:
+        tuple: (AuthorizedSession, network_code str), or (None, None) on error.
+    """
+    if not network_code:
+        try:
+            network_code = config.get_value('google_ad_manager', 'network_code')
+        except (KeyError, NoOptionError):
+            print('No network code was provided')
+            return None, None
+
+    credentials = service_account.Credentials.from_service_account_file(
+        KEY_FILE,
+        scopes=[GAM_REST_SCOPE],
+    )
+    session = AuthorizedSession(credentials)
+    return session, str(network_code)
+
+
+def get_resource_from_admanager(
+    resource: str,
+    filter_str: str = None,
+    page_size: int = None,
+    order_by: str = None,
+    network_code=None,
+) -> pd.DataFrame:
+    """
+    Fetches a complete list of a specified resource from Google Ad Manager
+    via the REST (Beta) API.
+
+    Handles pagination automatically using nextPageToken to retrieve all
+    entities matching the query.
+
+    Args:
+        resource (str): The resource type to fetch. Must be a key in the
+            resource_map (e.g. 'PrivateAuction', 'PrivateAuctionDeal').
+        filter_str (str): Optional filter expression in GAM REST filter syntax,
+            e.g. "displayName = 'My Auction'".
+        page_size (int): Items per page (max 1000, default 1000).
+        order_by (str): Optional ordering expression, e.g. 'displayName ASC'.
+        network_code (int|str): GAM network code. Falls back to config.ini.
+
+    Returns:
+        pd.DataFrame: All items across all pages, one row per item. Returns
+            an empty DataFrame on auth failure or a failed request.
+
+    Raises:
+        ValueError: If the provided resource is not supported.
+    """
+    resource_map = {
+        'PrivateAuction': 'privateAuctions',
+        'PrivateAuctionDeal': 'privateAuctionDeals',
+    }
+
+    if resource not in resource_map:
+        raise ValueError(
+            f"Unsupported resource: '{resource}'. "
+            f"Supported resources are: {list(resource_map.keys())}"
+        )
+
+    resource_path = resource_map[resource]
+    print(f"Initializing REST connection to fetch '{resource}' entities...")
+
+    session, network_code = init_gam_rest_connection(network_code)
+    if session is None:
+        return pd.DataFrame()
+
+    url = f'{GAM_REST_BASE_URL}/networks/{network_code}/{resource_path}'
+    params = {'pageSize': page_size or GAM_REST_DEFAULT_PAGE_SIZE}
+    if filter_str:
+        params['filter'] = filter_str
+    if order_by:
+        params['orderBy'] = order_by
+
+    all_items = []
+    page_number = 1
+
+    while True:
+        print(f'Fetching page {page_number} (pageSize: {params["pageSize"]})...')
+        response = session.get(url, params=params)
+
+        if not response.ok:
+            print(f'Request failed ({response.status_code}): {response.text}')
+            return pd.DataFrame()
+
+        data = response.json()
+        items = data.get(resource_path, [])
+        num_results = len(items)
+        print(f'-> Found {num_results} items on this page.')
+
+        all_items.extend(items)
+
+        next_page_token = data.get('nextPageToken')
+        if not next_page_token:
+            break
+
+        params['pageToken'] = next_page_token
+        page_number += 1
+
+    print(f"Successfully fetched a total of {len(all_items)} '{resource}' items.\n")
+    return pd.DataFrame(all_items)
+
+
+def get_private_auctions_from_admanager(
+    filter_str: str = None,
+    page_size: int = None,
+    order_by: str = None,
+    network_code=None,
+) -> pd.DataFrame:
+    """
+    Fetches all Private Auctions from Google Ad Manager via the REST (Beta) API.
+
+    Reference:
+        https://developers.google.com/ad-manager/api/beta/reference/rest/v1/networks.privateAuctions
+
+    Args:
+        filter_str (str): Optional filter expression,
+            e.g. "displayName = 'My Auction'".
+        page_size (int): Items per page (max 1000, default 1000).
+        order_by (str): Optional ordering, e.g. 'displayName ASC'.
+        network_code (int|str): GAM network code. Falls back to config.ini.
+
+    Returns:
+        pd.DataFrame: One row per private auction.
+    """
+    return get_resource_from_admanager(
+        resource='PrivateAuction',
+        filter_str=filter_str,
+        page_size=page_size,
+        order_by=order_by,
+        network_code=network_code,
+    )
+
+
+def get_private_auction_deals_from_admanager(
+    filter_str: str = None,
+    page_size: int = None,
+    order_by: str = None,
+    network_code=None,
+) -> pd.DataFrame:
+    """
+    Fetches all Private Auction Deals from Google Ad Manager via the REST (Beta) API.
+
+    Reference:
+        https://developers.google.com/ad-manager/api/beta/reference/rest/v1/networks.privateAuctionDeals
+
+    Args:
+        filter_str (str): Optional filter expression,
+            e.g. "status = 'ACTIVE'".
+        page_size (int): Items per page (max 1000, default 1000).
+        order_by (str): Optional ordering, e.g. 'createTime DESC'.
+        network_code (int|str): GAM network code. Falls back to config.ini.
+
+    Returns:
+        pd.DataFrame: One row per private auction deal.
+    """
+    return get_resource_from_admanager(
+        resource='PrivateAuctionDeal',
+        filter_str=filter_str,
+        page_size=page_size,
+        order_by=order_by,
+        network_code=network_code,
+    )

--- a/sroka/api/google_ad_manager/gam_rest_api.py
+++ b/sroka/api/google_ad_manager/gam_rest_api.py
@@ -46,6 +46,7 @@ def get_resource_from_admanager(
     filter_str: str = None,
     page_size: int = None,
     order_by: str = None,
+    columns_to_keep: list = None,
     network_code=None,
 ) -> pd.DataFrame:
     """
@@ -62,6 +63,8 @@ def get_resource_from_admanager(
             e.g. "displayName = 'My Auction'".
         page_size (int): Items per page (max 1000, default 1000).
         order_by (str): Optional ordering expression, e.g. 'displayName ASC'.
+        columns_to_keep (list): Optional list of column names to include in the
+            returned DataFrame. If None, all columns are returned.
         network_code (int|str): GAM network code. Falls back to config.ini.
 
     Returns:
@@ -122,13 +125,17 @@ def get_resource_from_admanager(
         page_number += 1
 
     print(f"Successfully fetched a total of {len(all_items)} '{resource}' items.\n")
-    return pd.DataFrame(all_items)
+    df = pd.DataFrame(all_items)
+    if columns_to_keep and not df.empty:
+        df = df[columns_to_keep]
+    return df
 
 
 def get_private_auctions_from_admanager(
     filter_str: str = None,
     page_size: int = None,
     order_by: str = None,
+    columns_to_keep: list = None,
     network_code=None,
 ) -> pd.DataFrame:
     """
@@ -142,6 +149,8 @@ def get_private_auctions_from_admanager(
             e.g. "displayName = 'My Auction'".
         page_size (int): Items per page (max 1000, default 1000).
         order_by (str): Optional ordering, e.g. 'displayName ASC'.
+        columns_to_keep (list): Optional list of column names to include in the
+            returned DataFrame. If None, all columns are returned.
         network_code (int|str): GAM network code. Falls back to config.ini.
 
     Returns:
@@ -152,6 +161,7 @@ def get_private_auctions_from_admanager(
         filter_str=filter_str,
         page_size=page_size,
         order_by=order_by,
+        columns_to_keep=columns_to_keep,
         network_code=network_code,
     )
 
@@ -160,6 +170,7 @@ def get_private_auction_deals_from_admanager(
     filter_str: str = None,
     page_size: int = None,
     order_by: str = None,
+    columns_to_keep: list = None,
     network_code=None,
 ) -> pd.DataFrame:
     """
@@ -173,6 +184,8 @@ def get_private_auction_deals_from_admanager(
             e.g. "status = 'ACTIVE'".
         page_size (int): Items per page (max 1000, default 1000).
         order_by (str): Optional ordering, e.g. 'createTime DESC'.
+        columns_to_keep (list): Optional list of column names to include in the
+            returned DataFrame. If None, all columns are returned.
         network_code (int|str): GAM network code. Falls back to config.ini.
 
     Returns:
@@ -183,5 +196,6 @@ def get_private_auction_deals_from_admanager(
         filter_str=filter_str,
         page_size=page_size,
         order_by=order_by,
+        columns_to_keep=columns_to_keep,
         network_code=network_code,
     )


### PR DESCRIPTION
internal ID: MONDE-304

### Add GAM REST (Beta) API connection
  
  New file: sroka/api/google_ad_manager/gam_rest_api.py

  Adds a connection to the Google Ad Manager REST (Beta) API, structured to
  match the existing SOAP API pattern in gam_api.py.

  init_gam_rest_connection(network_code) — authenticates using the same
  ad_manager.json service account key and network_code from config.ini already
  used by the SOAP connection. No new config entries required.
  
  get_resource_from_admanager(resource, filter_str, page_size, order_by, 
  network_code) — generic paginated fetcher, analogous to
  get_service_data_from_admanager on the SOAP side. Uses a resource_map to
  validate the resource name and resolve it to a REST path, handles
  nextPageToken-based pagination automatically, and returns a DataFrame. Raises
  ValueError for unsupported resources.

  Currently supported resources:
- PrivateAuction - networks/{networkCode}/privateAuctions
- PrivateAuctionDeal - networks/{networkCode}/privateAuctionDeals

get_private_auctions_from_admanager and
get_private_auction_deals_from_admanager — convenience wrappers over the
generic function, one per resource.
  
Adding future resources requires only a new entry in resource_map and an
optional wrapper function.

 ### requirements.txt

  - Added google-auth>=2.0.0 as an explicit direct dependency. Previously it was
  only a transitive dependency (via google-auth-httplib2); the REST API uses it
  directly for AuthorizedSession and service_account.Credentials.
